### PR TITLE
Attempt 1.21.1 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://jenkins.hellfiredev.net/job/AstralSorcery/job/1.16-indev/badge/icon)](https://jenkins.hellfiredev.net/job/AstralSorcery/job/1.16-indev/)
+[![Build Status](https://jenkins.hellfiredev.net/job/AstralSorcery/job/1.21-indev/badge/icon)](https://jenkins.hellfiredev.net/job/AstralSorcery/job/1.21-indev/)
 
 # Astral Sorcery
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ mixin {
     add sourceSets.main, "astralsorcery.refmap.json"
 }
 
-version = '1.16.4-1.14.1'
+version = '1.21.1-1.14.1'
 group = 'hellfirepvp.astralsorcery'
 archivesBaseName = 'astralsorcery'
 String build_version = ""

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,18 +20,18 @@ description='''Magic mod that draws power from stars and their constellations'''
 [[dependencies.astralsorcery]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.4]"
+    versionRange="[1.21.1]"
     ordering="NONE"
     side="BOTH"
 [[dependencies.astralsorcery]]
     modId="observerlib"
     mandatory=true
-    versionRange="[1.16.4-1.5,]"
+    versionRange="[1.21.1-1.5,]"
     ordering="NONE"
     side="BOTH"
 [[dependencies.astralsorcery]]
     modId="curios"
     mandatory=true
-    versionRange="[FORGE-1.16.3-,)"
+    versionRange="[FORGE-1.21.1-,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
## Summary
- bump mod version to 1.21.1 in build.gradle
- update dependency ranges to 1.21.1 in mods.toml
- adjust README badge for 1.21 build

## Testing
- `gradle build` *(fails: Could not resolve ForgeGradle)*